### PR TITLE
feat: Add title for select level section

### DIFF
--- a/src/components/select/SelectLevel.vue
+++ b/src/components/select/SelectLevel.vue
@@ -93,6 +93,11 @@ export default {
         star: {
             type: Number,
             default: 5,
+        },
+
+        title: {
+            type: String,
+            default: '',
         }
     },
     methods: {

--- a/src/pages/ArtifactsPlanPage/steps/ConfigCharacter.vue
+++ b/src/pages/ArtifactsPlanPage/steps/ConfigCharacter.vue
@@ -35,7 +35,7 @@
             ></el-input-number>
         </div>
 
-        <select-level :value="value | levelText" @input="handleChangeLevel"></select-level>
+        <select-level title="角色等级" :value="value | levelText" @input="handleChangeLevel"></select-level>
     </div>
 </template>
 

--- a/src/pages/ArtifactsPlanPage/steps/ConfigWeapon.vue
+++ b/src/pages/ArtifactsPlanPage/steps/ConfigWeapon.vue
@@ -20,6 +20,7 @@
         </div>
 
         <select-level
+            title="武器等级"
             :star="star"
             :value="levelText"
             @input="handleClickLevel"


### PR DESCRIPTION
一开始真没看出来这里是要选择等级, 感觉好像是上一个 section 的附属选项.
加个 title 使它看起来更像一个独立 section

![image](https://user-images.githubusercontent.com/6939365/112918852-73af5a80-9138-11eb-9be5-034b934b2330.png)
![image](https://user-images.githubusercontent.com/6939365/112918866-78740e80-9138-11eb-89a3-c868319bcfa9.png)
