### PR TITLE
feat: add multi account support

### DIFF
--- a/src/pages/AccountPage/AccountPage.vue
+++ b/src/pages/AccountPage/AccountPage.vue
@@ -1,0 +1,141 @@
+<template>
+    <div>
+        <el-breadcrumb>
+            <el-breadcrumb-item>账号</el-breadcrumb-item>
+        </el-breadcrumb>
+        <el-divider></el-divider>
+
+        <div class="toolbar">
+            <el-button
+                type="primary"
+                icon="el-icon-plus"
+                @click="addAccount"
+            >
+                添加账号
+            </el-button>
+        </div>
+
+        <div class="body">
+            <div
+                v-for="{id, name} in allAccounts"
+                :key="id"
+                class="item is-active"
+                :class="{ active: id === currentAccountId }"
+                @click="changeAccount(id)"
+            >
+                <click-edit-label
+                    :value="name"
+                    @input="newName => handleChangeName(id, name, newName)"
+                    fontsize="18px"
+                    :editable="true"
+                    style="display: inline-block;"
+                ></click-edit-label>
+                <div class="buttons flex-row">
+                    <el-popconfirm
+                        v-show="id !== currentAccountId"
+                        title="确定删除？"
+                        @confirm="deleteAccount(id)"
+                    >
+                        <el-button
+                            slot="reference"
+                            icon="el-icon-delete"
+                            type="text"
+                            size="medium"
+                            circle
+                            class="button"
+                            title="删除"
+                            @click.stop=""
+                        ></el-button>
+                    </el-popconfirm>
+                    <!-- <el-button
+                        icon="el-icon-download"
+                        type="text"
+                        size="medium"
+                        circle
+                        @click="handleDownload(name, item)"
+                        class="button"
+                        title="导出"
+                    ></el-button> -->
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapState } from "vuex";
+
+import ClickEditLabel from "@c/misc/ClickEditLabel";
+
+export default {
+    name: "AccountPage",
+    components: {
+        ClickEditLabel,
+    },
+    created() {
+        this.canCopy = !!navigator.clipboard;
+    },
+    computed: {
+        ...mapState("accounts", ["currentAccountId", "allAccounts"]),
+    },
+    methods: {
+        addAccount() {
+            this.$store.commit('accounts/addAccount', { name: '新账户' });
+        },
+        deleteAccount(id) {
+            this.$store.commit('accounts/deleteAccount', { id });
+        },
+        changeAccount(id) {
+            if (id !== this.currentAccountId) {
+                this.$store.dispatch('changeAccount', { id });
+            }
+        },
+        handleChangeName(id, oldName, newName) {
+            if (newName !== oldName && newName !== '') {
+                this.$store.commit('accounts/changeAccountName', { id, name: newName });
+            }
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.body {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.toolbar {
+    margin-bottom: 20px;
+}
+
+$height: 80px;
+
+.item {
+    height: $height;
+    width: 100%;
+    padding-left: 20px;
+    cursor: pointer;
+    line-height: $height;
+    color: #303133;
+    transition: 200ms;
+
+    &.active {
+        color: #409EFF;
+        background: #ecf5ff;
+    }
+
+    &:hover {
+        background: #ecf5ff;
+    }
+
+    .buttons {
+        float: right;
+        height: $height;
+
+        .button {
+            margin: 0;
+        }
+    }
+}
+</style>

--- a/src/pages/AccountPage/index.js
+++ b/src/pages/AccountPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AccountPage";

--- a/src/pages/ArtifactPotentialPage/ResultOfAll/ResultOfAll.vue
+++ b/src/pages/ArtifactPotentialPage/ResultOfAll/ResultOfAll.vue
@@ -71,6 +71,11 @@ export default {
             }
         }
     },
+    watch: {
+        "$store.state.accounts.currentAccountId"() {
+            this.result = [];
+        }
+    },
     computed: {
         finalResult() {
             let temp = this.result.slice();

--- a/src/pages/ArtifactsPlanPage/ArtifactsPlanPage.vue
+++ b/src/pages/ArtifactsPlanPage/ArtifactsPlanPage.vue
@@ -185,7 +185,7 @@
                 </div>
             </el-col>
         </el-row>
-        
+
     </div>
 </template>
 
@@ -240,6 +240,12 @@ export default {
             currentPresetName: "",
         }
     },
+    watch: {
+        "$store.state.accounts.currentAccountId"() {
+            this.isPreset = false;
+            this.currentPresetName = "";
+        }
+    },
     methods: {
         notifyChange(type, value) {
             // console.log(type, value);
@@ -286,7 +292,7 @@ export default {
 
         applyPreset(name) {
             let preset = this.$store.getters["presets/all"][name];
-            
+
             // set character
             // this.$refs.selectCharacter.setCharacterName(preset.character.name);
             this.$refs.configCharacter.setCharacterConfig(preset.character);
@@ -303,7 +309,7 @@ export default {
 
             // set constraint
             this.$refs.constraint.setConstraint(preset.constraint);
-            
+
             // set buffs
             this.$refs.configBuff.setBuffs(preset.buffs ?? []);
 
@@ -314,7 +320,7 @@ export default {
             this.$nextTick(() => {
                 this.$refs.calculator.updateConfigObject();
             });
-            
+
 
             this.$message({
                 type: "success",

--- a/src/pages/KumiPage/KumiPage.vue
+++ b/src/pages/KumiPage/KumiPage.vue
@@ -26,7 +26,7 @@
                 ></kumi-directory-display>
             </el-col>
         </el-row>
-        
+
     </div>
 </template>
 
@@ -45,8 +45,13 @@ export default {
             currentDirId: -1,
         }
     },
-    created() {
-        this.currentDirId = this.$store.getters["kumi/firstDirId"];
+    watch: {
+        "$store.state.accounts.currentAccountId": {
+            handler() {
+                this.currentDirId = this.$store.getters["kumi/firstDirId"];
+            },
+            immediate: true,
+        }
     },
     methods: {
         handleDeleteDir(id) {

--- a/src/pages/MainPage/SideBar.vue
+++ b/src/pages/MainPage/SideBar.vue
@@ -15,6 +15,10 @@
                 <template #title>
                     我的仓库
                 </template>
+                <el-menu-item index="/accounts">
+                    <i class="el-icon-user-solid"></i>
+                    账号
+                </el-menu-item>
                 <el-menu-item index="/artifacts">
                     <i class="el-icon-s-help"></i>
                     添加圣遗物
@@ -87,7 +91,7 @@
                         潜力函数
                     </el-menu-item>
                 </el-submenu>
-                
+
                 <el-menu-item index="/changelog">
                     <i class="el-icon-date"></i>
                     更新记录

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -59,11 +59,19 @@ const TargetFuncExplanationPage = () => import(/* webpackChunkName: "help-page" 
 const ExportToolPage = () => import(/* webpackChunkName: "help-page" */ "@page/helps/ExportToolPage");
 const ArtifactsStatisticsPage = () => import(/* webpackChunkName: "artifacts-statistics-page" */ "@page/ArtifactsStatisticsPage");
 const KumiPage = () => import (/* webpackChunkName: "kumi-page" */ "@page/KumiPage");
+const AccountPage = () => import (/* webpackChunkName: "account-page" */ "@page/AccountPage");
 
 
 const webName = process.env.WEB_TITLE;
 
 const routes = [
+    {
+        path: "/accounts",
+        component: AccountPage,
+        meta: {
+            title: "账号 | " + webName,
+        }
+    },
     {
         path: "/artifacts-kumi",
         component: KumiPage,

--- a/src/store/modules/accounts.js
+++ b/src/store/modules/accounts.js
@@ -1,0 +1,59 @@
+let nextId = 2;
+
+function initNextId(allAccounts) {
+    for (const {id} of allAccounts) {
+        nextId = Math.max(nextId, id);
+    }
+    nextId++;
+}
+
+const accounts = {
+    namespaced: true,
+    state: {
+        currentAccountId: 1,
+        allAccounts: [
+            { id: 1, name: '默认' },
+        ],
+    },
+    mutations: {
+        set(state, payload) {
+            state.currentAccountId = payload.currentAccountId;
+            state.allAccounts = payload.allAccounts;
+            initNextId(state.allAccounts);
+        },
+
+        setCurrentAccountId(state, { id }) {
+            state.currentAccountId = id;
+        },
+
+        addAccount(state, { name }) {
+            const account = {
+                id: nextId++,
+                name,
+            }
+            state.allAccounts = [...state.allAccounts, account];
+        },
+
+        deleteAccount(state, { id }) {
+            const allAccounts = state.allAccounts;
+            for (let i = 0, l = allAccounts.length; i < l; i++) {
+                if (allAccounts[i].id === id) {
+                    allAccounts.splice(i, 1);
+                    localStorage.removeItem(`mona_account_${id}`);
+                    break;
+                }
+            }
+        },
+
+        changeAccountName(state, { id, name }) {
+            for (const account of state.allAccounts) {
+                if (account.id === id) {
+                    account.name = name;
+                    break;
+                }
+            }
+        }
+    },
+};
+
+export default accounts;

--- a/src/store/modules/artifact.js
+++ b/src/store/modules/artifact.js
@@ -6,24 +6,12 @@ import positions from "@const/positions";
 // id can only be changed in store mutations
 let id = 0;
 
-let flower = [];
-let feather = [];
-let sand = [];
-let cup = [];
-let head = [];
-let hashes = new Map();
-let localStoredArtifacts = localStorage.getItem("artifacts");
-if (localStoredArtifacts) {
-    let obj = JSON.parse(localStoredArtifacts);
+const hashes = new Map();
 
-    flower = obj.flower || [];
-    feather = obj.feather || [];
-    sand = obj.sand || [];
-    cup = obj.cup || [];
-    head = obj.head || [];
-
-    let temp = flower.concat(feather).concat(sand).concat(cup).concat(head);
-    for (let item of temp) {
+function initIdAndHash(state) {
+    const { flower, feather, sand, cup, head } = state;
+    const allArtifacts = flower.concat(feather).concat(sand).concat(cup).concat(head);
+    for (const item of allArtifacts) {
         id = Math.max(id, item.id ?? -1);
         const hash = hashArtifact(item);
         if (hashes.has(hash)) {
@@ -33,10 +21,21 @@ if (localStoredArtifacts) {
         }
     }
     id++;
-    for (let item of temp) {
+    for (const item of allArtifacts) {
         if (!Object.prototype.hasOwnProperty.call(item, "id")) {
             item.id = id++;
         }
+    }
+}
+
+function updateHash(hash, inc) {
+    if (hashes.has(hash)) {
+        hashes.set(hash, hashes.get(hash) + inc);
+        if (hashes.get(hash) === 0) {
+            hashes.delete(hash);
+        }
+    } else {
+        hashes.set(hash, inc);
     }
 }
 
@@ -53,27 +52,40 @@ function findArtifact(state, id) {
     throw new Error("id not found");
 }
 
-function updateHash(hash, inc) {
-    if (hashes.has(hash)) {
-        hashes.set(hash, hashes.get(hash) + inc);
-        if (hashes.get(hash) === 0) {
-            hashes.delete(hash);
-        }
-    } else {
-        hashes.set(hash, inc);
-    }
-}
-
 let _store = {
     namespaced: true,
     state: {
-        flower,
-        feather,
-        sand,
-        cup,
-        head,
+        flower: [],
+        feather: [],
+        sand: [],
+        cup: [],
+        head: [],
     },
     mutations: {
+        oldInit(state) {
+            const localStoredArtifacts = localStorage.getItem("artifacts");
+            if (localStoredArtifacts) {
+                const obj = JSON.parse(localStoredArtifacts);
+                state.flower = obj.flower || [];
+                state.feather = obj.feather || [];
+                state.sand = obj.sand || [];
+                state.cup = obj.cup || [];
+                state.head = obj.head || [];
+                initIdAndHash(state);
+            }
+            // localStorage.removeItem("artifacts");
+        },
+
+        set(state, payload) {
+            payload = payload || {};
+            state.flower = payload.flower || [];
+            state.feather = payload.feather || [];
+            state.sand = payload.sand || [];
+            state.cup = payload.cup || [];
+            state.head = payload.head || [];
+            initIdAndHash(state);
+        },
+
         removeArtifact(state, { position, index }) {
             let art = state[position][index];
             if (art) {

--- a/src/store/modules/artifactKumi.js
+++ b/src/store/modules/artifactKumi.js
@@ -4,23 +4,7 @@ import getTreeNode from "../utils/getTreeNode";
 
 let id = 2;
 
-
-let tree = {
-    label: "root",
-    type: "dir",
-    id: 0,
-    children: [
-        {
-            label: "默认收藏夹",
-            type: "dir",
-            id: 1,
-        }
-    ],
-};
-
-let temp = localStorage.getItem("kumiTree");
-if (temp) {
-    tree = JSON.parse(temp).tree;
+function initId(tree) {
     let queue = [tree];
     while (queue.length > 0) {
         let p = queue.pop();
@@ -34,7 +18,6 @@ if (temp) {
         }
     }
     id++;
-    // console.log("next kumi node ID: " + id);
 }
 
 function getKumiFromTree(node) {
@@ -48,14 +31,46 @@ function getKumiFromTree(node) {
     return temp;
 }
 
+function getInitTree() {
+    return {
+        label: "root",
+        type: "dir",
+        id: 0,
+        children: [
+            {
+                label: "默认收藏夹",
+                type: "dir",
+                id: 1,
+            }
+        ],
+    };
+}
+
 
 export default {
     namespaced: true,
     state: {
         // kumi: {},
-        tree,
+        tree: getInitTree(),
     },
     mutations: {
+        oldInit(state) {
+            let temp = localStorage.getItem("kumiTree");
+            if (temp) {
+                const tree = JSON.parse(temp).tree;
+                initId(tree);
+                state.tree = tree;
+                // console.log("next kumi node ID: " + id);
+            }
+            // localStorage.removeItem("kumiTree");
+        },
+
+        set(state, payload) {
+            payload = payload || {};
+            state.tree = payload.tree || getInitTree();
+            initId(state.tree);
+        },
+
         // create artifacts group
         newKumi(state, { ids, label, under }) {
             let node = getTreeNode(state.tree, node => node.id === under);
@@ -164,7 +179,7 @@ export default {
     getters: {
         kumiByDir: state => {
             let temp = {};
-            
+
             for (let child of state.tree.children) {
                 temp[child.id] = getKumiFromTree(child);
             }

--- a/src/store/modules/presets.js
+++ b/src/store/modules/presets.js
@@ -5,61 +5,68 @@ import upgradePreset from "../utils/upgradePreset";
 const VERSION_PRESET = "2";
 const VERSION_PRESET_INT = parseInt(VERSION_PRESET);
 
-let temp = localStorage.getItem("presets");
-
-// presets form localStorage, might be out-versioned
-let presets = temp ? JSON.parse(temp) : {};
-
-let upgradedPresets = {};
-let upgradedCount = 0;
-let invalidCount = 0;
-
-// upgrade lower version presets
-for (let name in presets) {
-    if (!name) {
-        continue;
-    }
-    let preset = presets[name];
-    if (!preset) {
-        continue;
-    }
-
-    let version = parseInt(preset.version ?? "1");
-    if (version < VERSION_PRESET_INT) {
-        // need upgrade
-
-        try {
-            let newPreset = upgradePreset(preset);
-            newPreset.version = VERSION_PRESET;
-            upgradedPresets[newPreset.name] = newPreset;
-            upgradedCount++;
-        } catch (e) {
-            console.error(e);
-            invalidCount++;
-        }
-    } else {
-        // don't need upgrade
-        console.log("not upgrade");
-        upgradedPresets[preset.name] = preset;
-    }
-}
-
-if (invalidCount > 0 || upgradedCount > 0) {
-    Vue.nextTick(() => {
-        window.monaApp.message(`已升级预设，通过${upgradedCount}个，失败${invalidCount}个`);
-    });
-}
-if (upgradedCount > 0) {
-    localStorage.setItem("presets", JSON.stringify(upgradedPresets));
-}
-
 
 let item = {
     namespaced: true,
     state: {
-        presets: upgradedPresets,
+        presets: {},
     },
     mutations: {
+        oldInit(state) {
+            let temp = localStorage.getItem("presets");
+
+            // presets form localStorage, might be out-versioned
+            let presets = temp ? JSON.parse(temp) : {};
+
+            let upgradedPresets = {};
+            let upgradedCount = 0;
+            let invalidCount = 0;
+
+            // upgrade lower version presets
+            for (let name in presets) {
+                if (!name) {
+                    continue;
+                }
+                let preset = presets[name];
+                if (!preset) {
+                    continue;
+                }
+
+                let version = parseInt(preset.version ?? "1");
+                if (version < VERSION_PRESET_INT) {
+                    // need upgrade
+
+                    try {
+                        let newPreset = upgradePreset(preset);
+                        newPreset.version = VERSION_PRESET;
+                        upgradedPresets[newPreset.name] = newPreset;
+                        upgradedCount++;
+                    } catch (e) {
+                        console.error(e);
+                        invalidCount++;
+                    }
+                } else {
+                    // don't need upgrade
+                    console.log("not upgrade");
+                    upgradedPresets[preset.name] = preset;
+                }
+            }
+
+            if (invalidCount > 0 || upgradedCount > 0) {
+                Vue.nextTick(() => {
+                    window.monaApp.message(`已升级预设，通过${upgradedCount}个，失败${invalidCount}个`);
+                });
+            }
+
+            state.presets = upgradedPresets;
+            // localStorage.removeItem("presets");
+        },
+
+        set(state, payload) {
+            payload = payload || {};
+            state.presets = payload.presets || {};
+        },
+
         add(state, payload) {
             if (!Object.prototype.hasOwnProperty.call(state.presets, payload.name)) {
                 let preset = payload.value;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,59 +1,112 @@
 import Vuex from "vuex";
 import Vue from "vue";
 
+import accounts from "./modules/accounts";
 import artifacts from "./modules/artifact";
 import presets from "./modules/presets";
 import kumi from "./modules/artifactKumi";
 
+/**
+ * version 1 localStorage scheme:
+ * mona_meta: { version: 1 }
+ * mona_accounts: { currentAccountId: Number, allAccounts: [{ id: Number, name: String }, ...] }
+ * mona_account_<name>: { artifacts: {...}, presets: {...}, kumiTree: {...} }
+ */
+const VERSION_STORAGE = 1;
+
 Vue.use(Vuex);
+
+let loadingAccountData = false;
 
 const _store = new Vuex.Store({
     modules: {
+        accounts,
         artifacts,
         presets,
         kumi,
+    },
+    actions: {
+        loadAccountData({ commit, state }) {
+            loadingAccountData = true;
+            const key = `mona_account_${state.accounts.currentAccountId}`;
+            const accountString = localStorage.getItem(key);
+            const accountData = accountString ? JSON.parse(accountString) : {};
+            commit('artifacts/set', accountData.artifacts);
+            commit('presets/set', accountData.presets);
+            commit('kumi/set', accountData.kumiTree);
+            loadingAccountData = false;
+        },
+        changeAccount({ dispatch, commit }, { id }) {
+            commit('accounts/setCurrentAccountId', { id });
+            dispatch('loadAccountData');
+        }
     }
 });
 
-// watch artifacts change
+// init from localStorage
+const metaDataString = localStorage.getItem('mona_meta');
+if (!metaDataString) {
+    // load old data
+    _store.commit('artifacts/oldInit');
+    _store.commit('presets/oldInit');
+    _store.commit('kumi/oldInit');
+
+    const metaData = {
+        version: VERSION_STORAGE,
+    };
+    localStorage.setItem('mona_meta', JSON.stringify(metaData));
+} else {
+    const metaData = JSON.parse(metaDataString);
+    if (metaData.version !== VERSION_STORAGE) {
+        // update local storage here
+    } else {
+        const payload = JSON.parse(localStorage.getItem('mona_accounts'));
+        _store.commit('accounts/set', payload);
+        _store.dispatch('loadAccountData');
+    }
+}
+
+// watch accounts
 _store.watch(
-    state => ({
-        flower: state.artifacts.flower,
-        feather: state.artifacts.feather,
-        sand: state.artifacts.sand,
-        cup: state.artifacts.cup,
-        head: state.artifacts.head,
-    }),
+    state => state.accounts,
     newValue => {
-        localStorage.setItem("artifacts", JSON.stringify(newValue));
+        localStorage.setItem('mona_accounts', JSON.stringify(newValue));
     },
     {
         deep: true,
-    },
+        immediate: true,
+    }
 );
 
-// watch presets change
+// watch account state change
 _store.watch(
-    state => state.presets.presets,
+    state => ({
+        artifacts: state.artifacts,
+        presets: state.presets,
+        kumiTree: state.kumi,
+        // artifacts: {
+        //     flower: state.artifacts.flower,
+        //     feather: state.artifacts.feather,
+        //     sand: state.artifacts.sand,
+        //     cup: state.artifacts.cup,
+        //     head: state.artifacts.head,
+        // },
+        // presets: state.presets.presets,
+        // kumiTree: {
+        //     tree: state.kumi.tree,
+        // },
+    }),
     newValue => {
-        localStorage.setItem("presets", JSON.stringify(newValue));
+        if (loadingAccountData) {
+            return;
+        }
+        const key = `mona_account_${_store.state.accounts.currentAccountId}`;
+        localStorage.setItem(key, JSON.stringify(newValue));
     },
     {
         deep: true,
-    }
-)
-
-// watch artifact group change
-_store.watch(
-    state => ({
-        tree: state.kumi.tree,
-    }),
-    newValue => {
-        localStorage.setItem("kumiTree", JSON.stringify(newValue));
+        immediate: true,
     },
-    {
-        deep: true
-    }
 );
 
 export default _store;


### PR DESCRIPTION
添加了切换账号的页面，如下
![image](https://user-images.githubusercontent.com/12966985/154858654-574b1b58-cf7d-4da3-bd7a-9654424e0eee.png)
点击文字可以直接改名。个人不是很会设计页面，可能有更好的呈现方式。

每个账号存储的信息与原来localStorage中的信息保持一致，新的储存格式可见store.js。

兼容性上，可以自动从旧格式转换成新格式（且没有删除原来localStorage中的字段）。

对于一些keep-alive的页面，通过添加watch使得切换账号后也能保持在合法的状态。

自己测试了几遍，暂未发现bug。
