### PR TITLE
fix: unable to switch character bug

### DIFF
--- a/src/pages/NewArtifactPlanPage/DamagePanel.vue
+++ b/src/pages/NewArtifactPlanPage/DamagePanel.vue
@@ -47,54 +47,54 @@ export default {
         // }
     },
     computed: {
-        element() {
-            return this.analysisFromWasm.element
-        },
-
-        normalDamageTitle() {
-            if (this.analysisFromWasm.is_heal) {
-                return "治疗"
-            } else {
-                const map = {
-                    "Pyro": "火元素伤害",
-                    "Hydro": "水元素伤害",
-                    "Electro": "雷元素伤害",
-                    "Cryo": "冰元素伤害",
-                    "Dendro": "草元素伤害",
-                    "Geo": "岩元素伤害",
-                    "Anemo": "风元素伤害",
-                    "Physical": "物理伤害",
-                }
-                return map[this.element]
-            }
-        },
-
         tableData() {
-            let temp = []
-            const NO_DATA = "无数据"
+            const result = this.analysisFromWasm
+            if (!result) {
+                return []
+            }
 
-            const r = (x) => Math.round(x)
+            const r = Math.round
 
-            temp.push({
-                expectation: r(this.analysisFromWasm.normal?.expectation) ?? NO_DATA,
-                critical: r(this.analysisFromWasm.normal?.critical) ?? NO_DATA,
-                nonCritical: r(this.analysisFromWasm.normal?.non_critical) ?? NO_DATA,
-                name: this.normalDamageTitle
-            })
+            const temp = []
 
+            if (this.analysisFromWasm.normal) {
+                let normalDamageTitle
+                if (this.analysisFromWasm.is_heal) {
+                    normalDamageTitle = "治疗"
+                } else {
+                    const map = {
+                        "Pyro": "火元素伤害",
+                        "Hydro": "水元素伤害",
+                        "Electro": "雷元素伤害",
+                        "Cryo": "冰元素伤害",
+                        "Dendro": "草元素伤害",
+                        "Geo": "岩元素伤害",
+                        "Anemo": "风元素伤害",
+                        "Physical": "物理伤害",
+                    }
+                    normalDamageTitle = map[result.element]
+                }
+
+                temp.push({
+                    expectation: r(this.analysisFromWasm.normal.expectation),
+                    critical: r(this.analysisFromWasm.normal.critical),
+                    nonCritical: r(this.analysisFromWasm.normal.non_critical),
+                    name: normalDamageTitle
+                })
+            }
             if (this.analysisFromWasm.melt) {
                 temp.push({
-                    expectation: r(this.analysisFromWasm.melt?.expectation) ?? NO_DATA,
-                    critical: r(this.analysisFromWasm.melt?.critical) ?? NO_DATA,
-                    nonCritical: r(this.analysisFromWasm.melt?.non_critical) ?? NO_DATA,
+                    expectation: r(this.analysisFromWasm.melt.expectation),
+                    critical: r(this.analysisFromWasm.melt.critical),
+                    nonCritical: r(this.analysisFromWasm.melt.non_critical),
                     name: "融化"
                 })
             }
             if (this.analysisFromWasm.vaporize) {
                 temp.push({
-                    expectation: r(this.analysisFromWasm.vaporize?.expectation) ?? NO_DATA,
-                    critical: r(this.analysisFromWasm.vaporize?.critical) ?? NO_DATA,
-                    nonCritical: r(this.analysisFromWasm.vaporize?.non_critical) ?? NO_DATA,
+                    expectation: r(this.analysisFromWasm.vaporize.expectation),
+                    critical: r(this.analysisFromWasm.vaporize.critical),
+                    nonCritical: r(this.analysisFromWasm.vaporize.non_critical),
                     name: "蒸发"
                 })
             }
@@ -118,7 +118,7 @@ export default {
     }
 
     .name {
-        
+
     }
 
     .numbers {

--- a/src/pages/NewArtifactPlanPage/NewArtifactPlanPage.vue
+++ b/src/pages/NewArtifactPlanPage/NewArtifactPlanPage.vue
@@ -157,7 +157,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <p class="common-title2">过滤圣遗物组</p>
             <div style="max-height: 50vh; overflow: auto" class="mona-scroll">
                 <el-tree
@@ -707,6 +707,8 @@ import EnemyConfig from "./EnemyConfig"
 import SelectArtifactMainStat from "@c/select/SelectArtifactMainStat"
 import ArtifactConfig from "./ArtifactConfig"
 
+let wasmCalculated = false
+
 export default {
     name: "NewArtifactPlanPage",
     components: {
@@ -821,6 +823,9 @@ export default {
             miscBigContainerHeight: "",
             miscPerStatBonus: {},
             miscCurrentPresetName: null,
+
+            characterDamageAnalysis: null,
+            characterTransformativeDamage: null,
         }
     },
     computed: {
@@ -923,16 +928,6 @@ export default {
             }
         },
 
-        characterDamageAnalysis() {
-            const temp = this.$mona.CalculatorInterface.get_damage_analysis(this.damageAnalysisWasmInterface)
-            // console.log(temp)
-            return temp
-        },
-
-        characterTransformativeDamage() {
-            return this.$mona.CalculatorInterface.get_transformative_damage(this.damageAnalysisWasmInterface)
-        },
-
         // weapon
         weaponLevelNumber() {
             return parseInt(this.weaponLevel)
@@ -941,7 +936,7 @@ export default {
         weaponAscend() {
             return this.weaponLevel.includes("+")
         },
-        
+
         weaponSplash() {
             const data = weaponData[this.weaponName]
             return data.gacha ?? data.url ?? data.tn
@@ -1723,6 +1718,22 @@ export default {
                 // console.log(this.artifactSingleConfig)
             }
         },
+
+        damageAnalysisWasmInterface: {
+            handler() {
+                wasmCalculated = false
+                this.$nextTick(() => {
+                    // debounce
+                    if (!wasmCalculated) {
+                        this.characterDamageAnalysis = this.$mona.CalculatorInterface.get_damage_analysis(this.damageAnalysisWasmInterface)
+                        this.characterTransformativeDamage = this.$mona.CalculatorInterface.get_transformative_damage(this.damageAnalysisWasmInterface)
+                        wasmCalculated = true
+                    }
+                })
+            },
+            immediate: true,
+            deep: true,
+        },
     }
 };
 
@@ -1766,7 +1777,7 @@ export default {
     .left-container {
         // flex: 1;
         padding-right: 12px;
-        
+
     }
 
     .middle-container {
@@ -1795,7 +1806,7 @@ export default {
         align-items: center;
 
         .artifact-item-or-button {
-            
+
         }
     }
 }
@@ -1872,7 +1883,7 @@ export default {
         .detail-left {
             width: 64px;
             margin-right: 16px;
-            
+
             img {
                 height: 64px;
                 width: 64px;

--- a/src/pages/NewArtifactPlanPage/TransformativeDamage.vue
+++ b/src/pages/NewArtifactPlanPage/TransformativeDamage.vue
@@ -29,6 +29,9 @@ export default {
     props: ["data"],
     computed: {
         tableDataForElementUI() {
+            if (!this.data) {
+                return []
+            }
             let results = []
             results.push({ chs: "感电", value: this.data.electro_charged })
             results.push({ chs: "超载", value: this.data.overload })


### PR DESCRIPTION
之前安伯选择“箭雨总伤害”后切换可莉会失败，原因在于传入wasm的数据是未完全更新的值，需要等到nextTick才行。同时加入debounce避免无用的重复计算。