### PR TITLE
Add BuffGraph

### DIFF
--- a/src/pages/NewArtifactPlanPage/BuffGraph.vue
+++ b/src/pages/NewArtifactPlanPage/BuffGraph.vue
@@ -1,0 +1,163 @@
+<template>
+    <div class="root">
+        <div class="pie-chart">
+            <v-chart :option="optionsForPieChart" :autoresize="true"></v-chart>
+        </div>
+        <div class="line-chart" :style="{ height: data.length * 40 + 130 + 'px' }">
+            <v-chart :option="optionsForECharts" :autoresize="true"></v-chart>
+        </div>
+    </div>
+</template>
+
+<script>
+import { useI18n } from "@/i18n/i18n";
+import { use } from "echarts/core"
+import { LineChart, PieChart } from "echarts/charts"
+import {
+    TooltipComponent,
+    ToolboxComponent,
+    LegendComponent,
+    GridComponent,
+    TitleComponent,
+} from "echarts/components"
+import { CanvasRenderer } from "echarts/renderers"
+import { deviceIsPC } from "@util/device"
+import VChart from "vue-echarts"
+
+use([
+    CanvasRenderer,
+    LineChart,
+    PieChart,
+    TooltipComponent,
+    ToolboxComponent,
+    LegendComponent,
+    TitleComponent,
+    GridComponent
+])
+
+export default defineComponent({
+    name: "BuffGraph",
+    props: ["data"],
+    components: { VChart },
+    computed: {
+        optionsForPieChart() {
+            let dataSingle = []
+            let factor = 1
+            let ln = 0
+            for (let i of this.data.slice(1)) {
+                factor *= (i.data + 100) / 100
+                ln += Math.log((i.data + 100) / 100)
+            }
+            let ratio = (factor - 1) / factor
+            dataSingle.push({
+                value: 1 / factor * 100,
+                name: this.data[0].name
+            })
+            for (let i of this.data.slice(1)) {
+                dataSingle.push({
+                    value: Math.log((i.data + 100) / 100) / ln * ratio * 100,
+                    name: i.name
+                })
+            }
+            return {
+                title: {
+                    text: "伤害占比",
+                    left: "center",
+                },
+                tooltip: {
+                    trigger: "item",
+                    formatter: (params) => {
+                        return `${params.name} ${params.value.toFixed(2)}%`
+                    }
+                },
+                series: [
+                    {
+                        type: "pie",
+                        radius: "60%",
+                        center: ["50%", "50%"],
+                        data: dataSingle,
+                    }
+                ]
+            }
+        },
+
+        optionsForECharts() {
+            const option = {
+                title: {
+                    text: "等效独立增伤",
+                    left: "center",
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    formatter: (params) => {
+                        return `${params[0].name} ${params[0].value.toFixed(2)}%`
+                    }
+                },
+                toolbox: deviceIsPC ? {
+                    feature: {
+                        saveAsImage: {}
+                    }
+                } : {},
+                yAxis: {
+                    type: "category",
+                    data: this.data.map(i => i.name),
+                    show: false,
+                },
+                xAxis: {
+                    axisLabel: {
+                        formatter: (value, index) => {
+                            return `${value.toFixed(0)}%`
+                        }
+                    }
+                },
+                series: {
+                    data: this.data.map(i => i.data),
+                    type: 'bar',
+                    itemStyle: {
+                        color: function (params) {
+                            const colors = ['#5470c6', '#91cc75', '#fac858', '#ee6666', '#73c0de', '#3ba272', '#fc8452', '#9a60b4', '#ff88e0'];
+                            return colors[params.dataIndex % colors.length];
+                        }
+                    }
+                },
+            }
+            return option
+        }
+    },
+    data() {
+        return {
+            deviceIsPC,
+        }
+    },
+    methods: {
+
+    },
+    setup() {
+        const { t } = useI18n()
+
+        return {
+            t
+        }
+    }
+})
+</script>
+    
+<style scoped lang="scss">
+canvas {
+    overflow: visible;
+}
+
+.root {
+    overflow: visible;
+    height: fit-content;
+}
+
+.line-chart {
+    width: 100%;
+}
+
+.pie-chart {
+    width: 100%;
+    height: 400px;
+}
+</style>

--- a/src/pages/NewArtifactPlanPage/NewArtifactPlanPage.vue
+++ b/src/pages/NewArtifactPlanPage/NewArtifactPlanPage.vue
@@ -614,6 +614,13 @@
                     ></damage-panel>
                 </div>
 
+                <template v-for="category of buffGraphData" :key="category.category">
+                    <h3 class="common-title2">{{ category.category }}</h3>
+                    <buff-graph
+                        :data="category.data"
+                    ></buff-graph>
+                </template>
+
                 <h3 class="common-title2" style="margin-top: 24px">{{ t("calcPage.dmg2") }}</h3>
                 <transformative-damage
                     :data="characterTransformativeDamage"
@@ -699,7 +706,8 @@ import {useRoute} from "vue-router"
 import {useI18n} from "@/i18n/i18n"
 import {useAccountStore} from "@/store/pinia/account"
 import {artifactsData} from "@/assets/artifacts"
-
+import BuffGraph from "./BuffGraph"
+import { buffData } from "@buff"
 import {ElMessage} from "element-plus"
 import "element-plus/es/components/message/style/css"
 import SelectElementType from "@/components/select/SelectElementType.vue";
@@ -1149,6 +1157,38 @@ const damageAnalysisWasmInterface = computed(() => {
         skill: characterSkillInterface.value,
         enemy: enemyInterface.value,
     }
+})
+
+const buffGraphData = computed(() => {
+    let result = []
+    let fumo2 = null
+    if (fumo.value !== "None") {
+        fumo2 = fumo.value
+    }
+    let base = damageAnalysisWasmInterface.value
+    let js = JSON.stringify(base)
+    let odmg = mona.CalculatorInterface.get_damage_analysis(base, fumo2)
+    let category = ["normal", "vaporize", "melt", "aggravate", "spread"]
+    let c2 = ["正常伤害占比", "蒸发伤害占比", "融化伤害占比", "超激化伤害占比", "蔓激化伤害占比"]
+    for (let c = 0; c < 5; c++) {
+        if (odmg[category[c]]) {
+            let data = []
+            for (let i = 0; i < base.buffs.length; i++) {
+                let d = JSON.parse(js)
+                d.buffs.splice(i, 1)
+                let pdmg = mona.CalculatorInterface.get_damage_analysis(d, fumo2)
+                let n = odmg[category[c]].expectation * 100 / pdmg[category[c]].expectation - 100
+                if (n < 1e-5) {
+                    n = 0
+                }
+                data.push({ name: ta(buffData[base.buffs[i].name].nameLocale), data: n })
+            }
+            data.sort((a, b) => { return b.data - a.data })
+            data.unshift({ name: "基础伤害", data: 100 })
+            result.push({ category: c2[c], data: data })
+        }
+    }
+    return result
 })
 
 const characterDamageAnalysis = computed(() => {


### PR DESCRIPTION
添加所有生效BUFF的等效独立增伤图表

![image](https://user-images.githubusercontent.com/55215708/231963946-c581c065-1097-40f4-be86-17cd1679f198.png)

原理是，去除某BUFF后的伤害期望为e0，有该BUFF时的伤害期望为e1，等效独立增伤=`(e1 / e0 - 1) * 100%`

添加所有生效BUFF的收益伤害占比图表

![image](https://user-images.githubusercontent.com/55215708/231963564-9c4c2824-f19e-488f-939b-e09d9e442e19.png)

原理是，通过各BUFF的等效独立增伤计算该BUFF对总伤害的贡献率

![image](https://user-images.githubusercontent.com/55215708/231965714-394e7b1b-4ec4-4b52-af65-eb5e75f6c836.png)

通过对公式进行变形，实现了将基础伤害也算入了贡献中