### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-05-19"
+channel = "nightly"
 # components = ["rustc", "cargo"]
 targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
原channel已经不可获取，配置文件中更新为最新nightly版本