### PR TITLE
更新所有缺失的图标链接

### DIFF
--- a/mona_core/src/weapon/weapons/catalysts/sacrificial_jade.rs
+++ b/mona_core/src/weapon/weapons/catalysts/sacrificial_jade.rs
@@ -28,7 +28,7 @@ pub struct SacrificialJade;
 impl WeaponTrait for SacrificialJade {
     const META_DATA: WeaponStaticData = WeaponStaticData {
         name: WeaponName::SacrificialJade,
-        internal_name: "",
+        internal_name: "Catalyst_Yue",
         weapon_type: WeaponType::Catalyst,
         weapon_sub_stat: Some(WeaponSubStatFamily::CriticalRate80),
         weapon_base: WeaponBaseATKFamily::ATK454,

--- a/mona_generate/src/gen_meta/gen_artifact_meta.rs
+++ b/mona_generate/src/gen_meta/gen_artifact_meta.rs
@@ -1,9 +1,11 @@
 use askama::Template;
+use std::collections::HashMap;
 use mona::artifacts::artifact_trait::ArtifactMetaData;
 use mona::artifacts::ArtifactSetName;
 use mona::common::item_config_type::ItemConfig;
 use crate::gen_meta::gen_locale::get_index_mapping;
 use crate::utils::config_to_json;
+use crate::utils::icon_hashmap::ICON_HASHMAP;
 
 struct ArtifactMeta {
     name_locale: usize,
@@ -29,6 +31,12 @@ struct ArtifactMeta {
     sand_icon: String,
     goblet_icon: String,
     head_icon: String,
+
+    flower_hash: String,
+    feather_hash: String,
+    sand_hash: String,
+    goblet_hash: String,
+    head_hash: String,
 }
 
 #[derive(Template)]
@@ -37,14 +45,25 @@ struct ArtifactMetaTemplate {
     artifacts: Vec<ArtifactMeta>
 }
 
+fn get_icon_hash(icon_hashmap: &HashMap<&str, &str>, icon: &str) -> String {
+    icon_hashmap.get(icon).map_or(String::new(), |&hash| hash.to_string())
+}
+
 pub fn gen_artifact_meta_as_js_file() -> String {
     let mut data = Vec::new();
     let index_map = get_index_mapping();
+    let icon_hashmap = &ICON_HASHMAP;
 
     for i in 1_usize..ArtifactSetName::LEN {
         let e: ArtifactSetName = num::FromPrimitive::from_usize(i).unwrap();
         let meta: ArtifactMetaData = e.get_meta();
         let config4: Option<&'static [ItemConfig]> = e.get_config4();
+
+        let flower_icon: String = if let Some(_) = meta.flower { format!("UI_RelicIcon_{}_4", meta.internal_id) } else { String::new() };
+        let feather_icon: String = if let Some(_) = meta.feather { format!("UI_RelicIcon_{}_2", meta.internal_id) } else { String::new() };
+        let sand_icon: String = if let Some(_) = meta.sand { format!("UI_RelicIcon_{}_5", meta.internal_id) } else { String::new() };
+        let goblet_icon: String = if let Some(_) = meta.goblet { format!("UI_RelicIcon_{}_1", meta.internal_id) } else { String::new() };
+        let head_icon: String = if let Some(_) = meta.head { format!("UI_RelicIcon_{}_3", meta.internal_id) } else { String::new() };
 
         data.push(ArtifactMeta {
             name_locale: *index_map.get(&meta.name_locale).unwrap(),
@@ -63,11 +82,16 @@ pub fn gen_artifact_meta_as_js_file() -> String {
             sand: if let Some(ref x) = meta.sand { Some(*index_map.get(x).unwrap()) } else { None },
             goblet: if let Some(ref x) = meta.goblet { Some(*index_map.get(x).unwrap()) } else { None },
             head: if let Some(ref x) = meta.head { Some(*index_map.get(x).unwrap()) } else { None },
-            flower_icon: if let Some(_) = meta.flower { format!("UI_RelicIcon_{}_4", meta.internal_id) } else { String::new() },
-            feather_icon: if let Some(_) = meta.feather { format!("UI_RelicIcon_{}_2", meta.internal_id) } else { String::new() },
-            sand_icon: if let Some(_) = meta.sand { format!("UI_RelicIcon_{}_5", meta.internal_id) } else { String::new() },
-            goblet_icon: if let Some(_) = meta.goblet { format!("UI_RelicIcon_{}_1", meta.internal_id) } else { String::new() },
-            head_icon: if let Some(_) = meta.head { format!("UI_RelicIcon_{}_3", meta.internal_id) } else { String::new() }
+            flower_icon: flower_icon.clone(),
+            feather_icon: feather_icon.clone(),
+            sand_icon: sand_icon.clone(),
+            goblet_icon: goblet_icon.clone(),
+            head_icon: head_icon.clone(),
+            flower_hash: get_icon_hash(icon_hashmap, flower_icon.as_str()),
+            feather_hash: get_icon_hash(icon_hashmap, feather_icon.as_str()),
+            sand_hash: get_icon_hash(icon_hashmap, sand_icon.as_str()),
+            goblet_hash: get_icon_hash(icon_hashmap, goblet_icon.as_str()),
+            head_hash: get_icon_hash(icon_hashmap, head_icon.as_str()),
         })
     }
 

--- a/mona_generate/src/gen_meta/gen_character_meta.rs
+++ b/mona_generate/src/gen_meta/gen_character_meta.rs
@@ -6,6 +6,7 @@ use mona::common::item_config_type::ItemConfig;
 use lazy_static::lazy_static;
 use crate::gen_meta::gen_locale::get_index_mapping;
 use crate::utils::config_to_json;
+use crate::utils::icon_hashmap::ICON_HASHMAP;
 
 struct CharacterMeta {
     name: String,
@@ -13,6 +14,7 @@ struct CharacterMeta {
     internal_name: String,
     name_locale: usize,
     // icon_name: String,
+    icon_hash: String,
     star: usize,
     skill1_name_index: usize,
     skill2_name_index: usize,
@@ -40,6 +42,7 @@ struct CharacterMetaTemplate {
 pub fn gen_character_meta_as_js_file() -> String {
     let mut data: Vec<CharacterMeta> = Vec::new();
     let index_mapping = get_index_mapping();
+    let icon_hashmap = &ICON_HASHMAP;
 
     for i in 0_usize..CharacterName::LEN {
         let name_enum: CharacterName = num::FromPrimitive::from_usize(i).unwrap();
@@ -93,9 +96,13 @@ pub fn gen_character_meta_as_js_file() -> String {
 
         let name_locale = *index_mapping.get(&meta.name_locale).unwrap();
 
+        let icon_hash: String = icon_hashmap.get(meta.internal_name)
+            .map_or(String::new(), |&hash| hash.to_string());
+
         data.push(CharacterMeta {
             name: meta.name.to_string(),
             internal_name: String::from(meta.internal_name),
+            icon_hash,
             name_locale,
             star: meta.star as usize,
             skill1_name_index: *index_mapping.get(&meta.skill_name1).unwrap(),

--- a/mona_generate/src/gen_meta/gen_weapon_meta.rs
+++ b/mona_generate/src/gen_meta/gen_weapon_meta.rs
@@ -6,10 +6,12 @@ use mona::weapon::weapon_name::WeaponName;
 use mona::weapon::weapon_static_data::WeaponStaticData;
 use crate::gen_meta::gen_locale::get_index_mapping;
 use crate::utils::config_to_json;
+use crate::utils::icon_hashmap::ICON_HASHMAP;
 
 struct WeaponMetaDataForJS {
     name: String,
     internal_name: String,
+    icon_hash: String,
     name_index: usize,
     star: usize,
     t: String,
@@ -26,6 +28,7 @@ struct WeaponMetaAllForJS {
 pub fn gen_weapon_meta_as_js_file() -> String {
     let mut data: Vec<WeaponMetaDataForJS> = Vec::new();
     let index_map = get_index_mapping();
+    let icon_hashmap = &ICON_HASHMAP;
 
     for i in 0_usize..WeaponName::LEN {
         let weapon_name: WeaponName = num::FromPrimitive::from_usize(i).unwrap();
@@ -40,10 +43,14 @@ pub fn gen_weapon_meta_as_js_file() -> String {
             }
         }
 
+        let icon_hash: String = icon_hashmap.get(meta_data.internal_name)
+            .map_or(String::new(), |&hash| hash.to_string());
+
         let my_data = WeaponMetaDataForJS {
             name: weapon_name.to_string(),
             // internal_name: get_internal_weapon_name(weapon_name),
             internal_name: String::from(meta_data.internal_name),
+            icon_hash,
             name_index: *index_map.get(&meta_data.name_locale).unwrap(),
             star: meta_data.star,
             t: meta_data.weapon_type.to_string(),

--- a/mona_generate/src/utils/icon_hashmap.rs
+++ b/mona_generate/src/utils/icon_hashmap.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref ICON_HASHMAP: HashMap<&'static str, &'static str> = {
+        let data = vec![
+            ("Furina", "4da8d9d663e2e59f63c19815074074de"),
+            ("Neuvillette", "965af2f32a5376affcb99afb9915a23d"),
+            ("Wriothesley", "e2ea36ecfdb6f53717b1cadd394fbf49"),
+            ("Lyney", "15c0fae62ec91222148b753e5445c5fe"),
+            ("Charlotte", "99218c303fd1ca9cc53e052ebdd5cbf3"),
+            ("Freminet", "7ca0ad25c2cbb36cd55a8a19c1b2a39f"),
+            ("Lynette", "3163e147dc45dec9944d06355d778879"),
+            ("Momoka", "8e8c8c18039f5441d4f2f43757781ae0"),
+            ("Bow_Pledge", "2b3f4a4eef528e1150893d58c68a5de3"),
+            ("Bow_Ibis", "aef17fddf164e3ea98c4fd073a5f02a3"),
+            ("Bow_Mechanic", "98e0ebb9a9857e2b21deda9d8c574b89"),
+            ("Bow_Gurabad", "1cd241d13f320f3a0fbdfe378f423364"),
+            ("Bow_Vorpal", "d70cf7fcc37cfbce1a07f5f3e214f278"),
+            ("Catalyst_Iudex", "8f34b571d7e2d26e6c2ef2886defa86b"),
+            ("Catalyst_Wheatley", "74712841e6a4cc25e0a2a36874ac71d7"),
+            ("Catalyst_DandelionPoem", "b90f7edc1c4a6c0c132e00da99918d84"),
+            ("Catalyst_Vorpal", "d4f997c8b399ef27d027653ba73645a5"),
+            ("Catalyst_Yue", "93b6d05a8bc54d8eb69e4ed450c981c8"),
+            ("Pole_Shanty", "2dc8e2cc9ab49c1d0ff9f67b3c98a94d"),
+            ("Pole_Mechanic", "3333f73a195e3da1ed9a125658dfcf16"),
+            ("Pole_Vorpal", "6514981aeab437590ebbfe15f5aef671"),
+            ("Sword_Regalis", "1d603d4764cf292a12e268b8d8012688"),
+            ("Sword_Vorpal", "acde24e9fa3f3e8c14f40aa4cd1a9007"),
+            ("Sword_Machination", "b6259f0f93f824b169b50b6bc593dd08"),
+            ("Sword_Purewill", "9c06477c167aadef25d03b4ceb1320ba"),
+            ("Sword_Mechanic", "da80c69eada7e7fb6053b6301a6011ba"),
+            ("Claymore_Mechanic", "6dc1e808543a09ddc1daf1e76721cd3d"),
+            ("Claymore_Vorpal", "a76dd2c45f3bcfaf3f547d5c90bd20e2"),
+            ("Claymore_BeastTamer", "4add4bfe23684d374398998eb5eb247d"),
+            ("UI_RelicIcon_15032_4", "fadbbf8dbba05ad1ce0daeb4ebf89413"),
+            ("UI_RelicIcon_15032_2", "4ca24e57d1adc9f0247c6bffd164d8b7"),
+            ("UI_RelicIcon_15032_5", "9269d47e4a4edd517042c26fe534060e"),
+            ("UI_RelicIcon_15032_1", "4d2b22a334d4237ba2cce56aeb5bd023"),
+            ("UI_RelicIcon_15032_3", "2f69d44e2e79a05adbe0c9fe6391ea33"),
+            ("UI_RelicIcon_15031_4", "9babba990b561f2b031d5db4145c19a9"),
+            ("UI_RelicIcon_15031_2", "819b944729f2d5702f46d1403edba587"),
+            ("UI_RelicIcon_15031_5", "de01dcbf2911968336afbbb61b455831"),
+            ("UI_RelicIcon_15031_1", "b10902ae43e7f6d6619fe560829f7ba3"),
+            ("UI_RelicIcon_15031_3", "1f3958293c20e8a29f51b9f3ed259e12"),
+        ];
+
+        data.into_iter().collect()
+    };
+}

--- a/mona_generate/src/utils/mod.rs
+++ b/mona_generate/src/utils/mod.rs
@@ -4,6 +4,8 @@ use mona::common::item_config_type::{ItemConfig, ItemConfigType};
 use serde_json::json;
 use crate::gen_meta::gen_locale::get_index_mapping;
 
+pub mod icon_hashmap;
+
 pub fn config_to_json(config: &ItemConfig) -> String {
     let index_map = get_index_mapping();
     let name = config.name;

--- a/mona_generate/templates/artifact_meta_template.js
+++ b/mona_generate/templates/artifact_meta_template.js
@@ -1,6 +1,7 @@
 const template = "https://upload-bbs.mihoyo.com/game_record/genshin/equip/#.png"
-
+const newTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon_uceddf/#.png"
 const getIcon = name => template.replace("#", name)
+const getHash = md5 => newTemplate.replace("#", md5)
 
 export default {
     {% for a in artifacts %}
@@ -10,52 +11,72 @@ export default {
         nameLocale: {{a.name_locale}},
         minStar: {{ a.min_star }},
         maxStar: {{ a.max_star }},
-    {% if a.effect1.is_some() %}
+    {% if a.effect1.is_some() -%}
         effect1: {{a.effect1.unwrap()}},
-    {% endif %}
-    {% if a.effect2.is_some() %}
+    {%- endif %}
+    {% if a.effect2.is_some() -%}
         effect2: {{a.effect2.unwrap()}},
-    {% endif %}
-    {% if a.effect3.is_some() %}
+    {%- endif %}
+    {% if a.effect3.is_some() -%}
         effect3: {{a.effect3.unwrap()}},
-    {% endif %}
-    {% if a.effect4.is_some() %}
+    {%- endif %}
+    {% if a.effect4.is_some() -%}
         effect4: {{a.effect4.unwrap()}},
-    {% endif %}
-    {% if a.effect5.is_some() %}
+    {%- endif %}
+    {% if a.effect5.is_some() -%}
         effect5: {{a.effect5.unwrap()}},
-    {% endif %}
+    {%- endif %}
 
-        {% if a.flower.is_some() %}
+        {% if a.flower.is_some() -%}
         flower: {
             text: {{a.flower.unwrap()}},
+            {% if a.flower_hash == "" -%}
             url: getIcon("{{ a.flower_icon }}")
+            {% else -%}
+            url: getHash("{{ a.flower_hash }}")
+            {%- endif -%}
         },
-        {% endif %}
-        {% if a.feather.is_some() %}
+        {%- endif %}
+        {% if a.feather.is_some() -%}
         feather: {
             text: {{a.feather.unwrap()}},
+            {% if a.feather_hash == "" -%}
             url: getIcon("{{ a.feather_icon }}")
+            {% else -%}
+            url: getHash("{{ a.feather_hash }}")
+            {%- endif -%}
         },
-        {% endif %}
-        {% if a.sand.is_some() %}
+        {%- endif %}
+        {% if a.sand.is_some() -%}
         sand: {
             text: {{a.sand.unwrap()}},
+            {% if a.sand_hash == "" -%}
             url: getIcon("{{ a.sand_icon }}")
+            {% else -%}
+            url: getHash("{{ a.sand_hash }}")
+            {%- endif -%}
         },
-        {% endif %}
-        {% if a.goblet.is_some() %}
+        {%- endif %}
+        {% if a.goblet.is_some() -%}
         cup: {
             text: {{a.goblet.unwrap()}},
+            {% if a.goblet_hash == "" -%}
             url: getIcon("{{ a.goblet_icon }}")
+            {% else -%}
+            url: getHash("{{ a.goblet_hash }}")
+            {%- endif -%}
         },
-        {% endif %}
-        {% if a.head.is_some() %}
+        {%- endif %}
+        {% if a.head.is_some() -%}
         head: {
             text: {{a.head.unwrap()}},
+            {% if a.head_hash == "" -%}
             url: getIcon("{{ a.head_icon }}")
+            {% else -%}
+            url: getHash("{{ a.head_hash }}")
+            {%- endif -%}
         },
-        {% endif %}
+        {%- endif %}
         config4: [
             {% for config in a.config4 %}
             {{ config|e("none") }},

--- a/mona_generate/templates/character_meta_template.js
+++ b/mona_generate/templates/character_meta_template.js
@@ -7,8 +7,9 @@ import {{ c.name }}_splash from "@image/characters/{{ c.name }}_splash"
 
 // const template = "https://upload-bbs.mihoyo.com/game_record/genshin/character_icon/UI_AvatarIcon_#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
 const template = "https://upload-bbs.mihoyo.com/game_record/genshin/character_icon/UI_AvatarIcon_#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
-
+const newTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon_uceddf/#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
 const getName = name => template.replace("#", name)
+const getMd5 = md5 => newTemplate.replace("#", md5)
 
 export default {
     {% for c in characters %}
@@ -20,7 +21,11 @@ export default {
         star: {{ c.star }},
         // card: {{ c.name }}_card,
         // avatar: {{ c.name }}_avatar,
+        {% if c.icon_hash == "" -%}
         avatar: getName("{{ c.internal_name }}"),
+        {% else -%}
+        avatar: getMd5("{{ c.icon_hash }}"),
+        {%- endif %}
         splash: {{ c.name }}_splash,
         skillName1: {{ c.skill1_name_index }},
         skillName2: {{ c.skill2_name_index }},

--- a/mona_generate/templates/tf_meta_template.js
+++ b/mona_generate/templates/tf_meta_template.js
@@ -6,7 +6,9 @@ import {{ t.name }}_image from "@image/{{ t.badge_path }}"
 {% endfor %}
 
 const template = "https://upload-bbs.mihoyo.com/game_record/genshin/character_icon/#.png"
+const newTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon_uceddf/#.png"
 const getImage = name => template.replace("#", name)
+const getIcon = md5 => newTemplate.replace("#", md5)
 
 export default {
     {% for t in tfs %}
@@ -20,11 +22,13 @@ export default {
             {% endfor %}
         ],
         "for": "{{ t.four }}",
-        {% if t.badge_type == "character" %}
+        {% if t.badge_type == "character" && t.icon_hash == "" -%}
         badge: getImage("{{ t.character_icon_name }}"),
-        {% else %}
+        {%- else if t.badge_type == "character" -%}
+        badge: getIcon("{{ t.icon_hash }}"),
+        {%- else -%}
         badge: {{ t.name }}_image,
-        {% endif %}
+        {%- endif %}
         config: [
             {% for config in t.config %}
             {{ config|e("none") }},

--- a/mona_generate/templates/weapon_meta_template.js
+++ b/mona_generate/templates/weapon_meta_template.js
@@ -4,8 +4,9 @@
 // {% endfor %}
 
 const template = "https://upload-bbs.mihoyo.com/game_record/genshin/equip/UI_EquipIcon_#.png"
-
+const newTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon_uceddf/#.png"
 const imageUrl = name => template.replace("#", name)
+const newImageUrl = md5 => newTemplate.replace("#", md5)
 
 export default {
 {% for weapon in weapons %}
@@ -14,7 +15,11 @@ export default {
         internalName: "{{ weapon.internal_name }}",
         nameLocale: {{weapon.name_index}},
         star: {{ weapon.star }},
+        {% if weapon.icon_hash == "" -%}
         url: imageUrl("{{ weapon.internal_name }}"),
+        {% else -%}
+        url: newImageUrl("{{ weapon.icon_hash }}"),
+        {%- endif %}
         type: "{{ weapon.t }}",
 
         {% if weapon.effect.is_some() %}


### PR DESCRIPTION
feat: Update Icon Urls

现学的 Rust，献丑了，您可以随意修改，还请多多赐教！
由于米游社对新素材更换了链接格式，不得不切换成 Hardcode 指向了。尽力维持了原有的代码逻辑。