### PR TITLE
feat: Added functionality to rename presets

### DIFF
--- a/src/components/display/PresetItem.vue
+++ b/src/components/display/PresetItem.vue
@@ -31,6 +31,15 @@
                     class="button"
                     :title="t('misc.export')"
                 ></el-button>
+              <el-button
+                  :icon="IconEpEdit"
+                  text
+                  size="small"
+                  circle
+                  @click.stop="$emit('rename')"
+                  class="button"
+                  :title="t('misc.rename')"
+              ></el-button>
             </div>
         </div>
         <div class="body">
@@ -59,8 +68,8 @@ import { weaponData } from "@weapon"
 import { targetFunctionData } from "@targetFunction"
 
 import IconFa6SolidDownload from "~icons/fa6-solid/download"
+import IconEpEdit from "~icons/ep/edit"
 import IconEpDelete from "~icons/ep/delete"
-import IconEpCPU from "~icons/ep/cpu"
 import {IPreset} from "@/types/preset"
 import {useI18n} from "@/i18n/i18n";
 

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -195,7 +195,9 @@ export default {
         exportAll: "Export All",
         go: "Please go to",
         toCalc: "page to add new presets",
-        wrongFormat: "Wrong format"
+        wrongFormat: "Wrong format",
+        renamePresetTitle:"Rename the preset",
+        renamePresetContent:"Please enter the new name for the preset",
     },
     calcPage: {
         selectArt: "Select Artifact",

--- a/src/i18n/locales/zh-cn.js
+++ b/src/i18n/locales/zh-cn.js
@@ -197,7 +197,9 @@ export default {
         exportAll: "导出全部",
         go: "请前往",
         toCalc: "页面添加预设",
-        wrongFormat: "导入格式错误"
+        wrongFormat: "导入格式错误",
+        renamePresetTitle:"重命名预设",
+        renamePresetContent:"请输入新的预设名字",
     },
     calcPage: {
         selectArt: "选择圣遗物",

--- a/src/pages/CharacterPresetsPage/CharacterPresetsPage.vue
+++ b/src/pages/CharacterPresetsPage/CharacterPresetsPage.vue
@@ -56,6 +56,7 @@
                 :calculate-icon="false"
                 @delete="handleDeletePreset(entry.name)"
                 @download="handleDownload(entry.name)"
+                @rename="handleRename(entry.name)"
                 class="item"
                 @click="handleClickPreset(entry.name)"
             ></preset-item>
@@ -151,6 +152,16 @@ function handleDownload(name: string) {
     const str = JSON.stringify(temp)
 
     downloadString(str, "application/json", name)
+}
+
+function handleRename(name:string){
+  ElMessageBox.prompt(t("presetPage.renamePresetContent"), t("presetPage.renamePresetTitle"), {
+    confirmButtonText: t("misc.confirm"),
+    cancelButtonText: t("misc.cancel"),
+    inputValue:name,
+  }).then(({ value }) => {
+    presetStore.renamePreset(name,value)
+  }).catch(() => {})
 }
 
 function handleExportAll() {

--- a/src/store/pinia/preset.ts
+++ b/src/store/pinia/preset.ts
@@ -49,6 +49,16 @@ function f() {
         return presets.value[name]
     }
 
+    function renamePreset(name:string,newName:string):boolean{
+        const preset = getPreset(name)
+        if(preset===undefined) return false
+        const item = preset.item
+        item.name = newName
+        deletePreset(name)
+        addOrOverwrite(newName,item)
+        return getPreset(newName)!==undefined
+    }
+
     function deletePreset(name: string) {
         delete presets.value[name]
     }
@@ -68,6 +78,7 @@ function f() {
         addOrOverwrite,
         deletePreset,
         getPreset,
+        renamePreset,
 
         allFlat,
         count


### PR DESCRIPTION
中文:

标题：增加预设重命名功能 #316 

描述：
本次PR实现了预设重命名功能。具体变更如下：
1. 在国际化文件en.js和zh-cn.js中，新增了'renamePresetTitle'和'renamePresetContent'字段，以支持预设的重命名。
2. 在PresetItem.vue组件中，添加了一个带有编辑图标的新按钮，并为其绑定了相应的事件监听器，用于重命名预设。
3. 在CharacterPresetsPage.vue页面中，添加了一个处理重命名事件的处理器，它会打开一个提示框，让用户输入新的预设名称。
4. 在preset.ts存储模块中，新增了一个名为'renamePreset'的函数，用于在应用状态中处理预设的重命名。
5. 对现有的组件和存储模块进行了一些小的修改，以支持新的重命名功能。

English:

Title: Added functionality to rename presets #316 

Description:
This PR introduces the ability to rename presets. The changes are as follows:
1. New fields 'renamePresetTitle' and 'renamePresetContent' were added to the i18n locales en.js and zh-cn.js files to support the renaming of presets.
2. A new button with an edit icon was added to the PresetItem.vue component, along with the corresponding event listener for renaming presets.
3. A handler for the rename event was added to the CharacterPresetsPage.vue page, which opens a prompt for users to enter a new preset name.
4. A new function 'renamePreset' was added to the preset.ts store module to handle the renaming of presets within the application state.
5. Minor adjustments were made to existing components and store modules to accommodate the new renaming functionality. 