### PR TITLE
菲谢尔优化目标改成激化伤害

### DIFF
--- a/mona_core/src/target_functions/target_functions/electro/fischl_default.rs
+++ b/mona_core/src/target_functions/target_functions/electro/fischl_default.rs
@@ -103,7 +103,7 @@ impl TargetFunction for FischlDefaultTargetFunction {
         type S = <Fischl as CharacterTrait>::DamageEnumType;
         let damage_e = Fischl::damage::<SimpleDamageBuilder>(
             &context, S::E1, &CharacterSkillConfig::NoConfig, None
-        ).normal.expectation;
+        ).aggravate.unwrap().expectation;
 
         damage_e
     }


### PR DESCRIPTION
菲谢尔主流配队以激化为主，应该优化激化伤害