### PR TITLE
fix: Add new avatar URL template for updated mihoyo character icon paths

### DIFF
--- a/mona_generate/templates/character_meta_template.js
+++ b/mona_generate/templates/character_meta_template.js
@@ -8,8 +8,28 @@ import {{ c.name }}_splash from "@image/characters/{{ c.name }}_splash"
 // const template = "https://upload-bbs.mihoyo.com/game_record/genshin/character_icon/UI_AvatarIcon_#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
 const template = "https://upload-bbs.mihoyo.com/game_record/genshin/character_icon/UI_AvatarIcon_#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
 const newTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon_u9b0pg/#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
+const newerTemplate = "https://act-webstatic.mihoyo.com/hk4e/e20200928calculate/item_icon/#.png?x-oss-process=image/crop,w_200,h_200,y_5,g_north"
+
+const avatarPathMap = {
+    "Kinich": "67c7f6c8/ec67809641b4f1d2d2e87bc0e1e88b93",
+    "Xilonen": "67c7f6c8/7c047dce3a1be70baa30f28111222e38",
+    "Chasca": "67c7f6c8/c009627a0c0289646a10d41779001b9d",
+    "Ororon": "67c7f6c8/64a90c55b4bb72cf06068f3d82dbc8da",
+    "Mavuika": "67c7f6c8/c54cf9fe971d6226b78ad795ced9bee8",
+    "Citlali": "67c7f6c8/abe2da348abe64c67d9c2763d2d8c4e7",
+    "Lanyan": "67c7f6c8/eba829f8ca4b38367c4a2551d0e228ae",
+    "YumemizukiMizuki": "67c7f6c8/1cebf43ac944ad3ff2a0581bebe309d8",
+    "Varesa": "67e3357c/34596fcb08c5c4b4e91379507e75dba7",
+    "Iansan": "67e3357c/f44e8b4c7a61a4abb2aa2ccfe9b810cd",
+    "Escoffier": "681a947b/6c4f7f722b0226a1171ec265485de61c",
+    "Ifa": "681a947b/0b3127bb721214a48b20001c64ab727a",
+    "Skirk": "6851f37b/b3007bcbb99dd9b47af558ecc1bb65ff",
+    "Dahlia": "6851f37b/9e5b1c5805948358c656e702e5eecae2",
+}
+
 const getName = name => template.replace("#", name)
 const getHash = hash => newTemplate.replace("#", hash)
+const getPath = path => newerTemplate.replace("#", path)
 
 export default {
     {% for c in characters %}
@@ -22,7 +42,7 @@ export default {
         // card: {{ c.name }}_card,
         // avatar: {{ c.name }}_avatar,
         {% if c.icon_hash == "" -%}
-        avatar: getName("{{ c.internal_name }}"),
+        avatar: avatarPathMap["{{ c.name }}"] ? getPath(avatarPathMap["{{ c.name }}"]) : getName("{{ c.internal_name }}"),
         {% else -%}
         avatar: getHash("{{ c.icon_hash }}"),
         {%- endif %}


### PR DESCRIPTION
添加新模板，适配米游社养成计算器中角色图标URL的新格式，以加载新角色的头像